### PR TITLE
Format cli output for --help

### DIFF
--- a/fuge.js
+++ b/fuge.js
@@ -113,17 +113,16 @@ var previewSystem = function(args) {
 
 
 var showHelp = function() {
-  console.log('');
   console.log('usage: fuge <command> <options>');
-  console.log('available commands');
-  console.log('generate [system | service] - generate a system or an additional system service');
-  console.log('build - build a system by executing the RUN commands in each services Dockerfile');
-  console.log('pull - update a system by attempting a git pull against each service');
-  console.log('run <compose file> - run a system');
-  console.log('preview <compose file> - preview a run command for a system');
-  console.log('shell <compose file> - start an interactive shell for a system');
-  console.log('version - version of fuge');
-  console.log('help - show this help');
+  console.log('');
+  console.log('fuge generate <system|service>  generate a system or an additional system service');
+  console.log('fuge build                      build a system by executing the RUN commands in each services Dockerfile');
+  console.log('fuge pull                       update a system by attempting a git pull against each service');
+  console.log('fuge run <compose-file>         run a system');
+  console.log('fuge preview <compose-file>     preview a run command for a system');
+  console.log('fuge shell <compose-file>       start an interactive shell for a system');
+  console.log('fuge version                    version of fuge');
+  console.log('fuge help                       show this help');
 };
 
 
@@ -153,6 +152,3 @@ module.exports = start;
 if (require.main === module) {
   start(process.argv.slice(2));
 }
-
-
-


### PR DESCRIPTION
Formatted the help option output for easier reading at a glance. Cleaned up inconsistent new lines in `fuge.js`.

Currently
```sh
$ fuge help

usage: fuge <command> <options>
available commands
generate [system | service] - generate a system or an additional system service
build - build a system by executing the RUN commands in each services Dockerfile
pull - update a system by attempting a git pull against each service
run <compose file> - run a system
preview <compose file> - preview a run command for a system
shell <compose file> - start an interactive shell for a system
help - show this help
```

Pull Request
```sh
$ fuge help
Usage: fuge <command> <options>

fuge generate <system|service> generate a system or an additional system service
fuge build                     build a system by executing the RUN commands in each services Dockerfile
fuge pull                      update a system by attempting a git pull against each service
fuge run <compose-file>        run a system
fuge preview <compose-file>    preview a run command for a system
fuge shell <compose-file>      start an interactive shell for a system
fuge help                      show this help
```