### PR TITLE
profile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The fuge shell supports the following commands:
 * **start [process]** - start a process
 * **start all** - start all stopped processes
 * **debug [process]** - start a process in debug mode and launch node-debug (experimental)
+* **profile [process]** - start a process with [0x](http://npm.im/0x), when the process is stopped a flamegraph will be generated in the services folder. 
 * **watch [process] | all** - turn on watching for a process or for all processes
 * **unwatch [process] | all** - turn off watching for a process or for all processes
 * **tail [process] | all** - tail output for a process or for all processes

--- a/fuge.js
+++ b/fuge.js
@@ -113,17 +113,16 @@ var previewSystem = function(args) {
 
 
 var showHelp = function() {
-  console.log('');
   console.log('usage: fuge <command> <options>');
-  console.log('available commands');
-  console.log('generate [system | service] - generate a system or an additional system service');
-  console.log('build - build a system by executing the RUN commands in each services Dockerfile');
-  console.log('pull - update a system by attempting a git pull against each service');
-  console.log('run <compose file> - run a system');
-  console.log('preview <compose file> - preview a run command for a system');
-  console.log('shell <compose file> - start an interactive shell for a system');
-  console.log('version - version of fuge');
-  console.log('help - show this help');
+  console.log('');
+  console.log('fuge generate <system|service>  generate a system or an additional system service');
+  console.log('fuge build                      build a system by executing the RUN commands in each services Dockerfile');
+  console.log('fuge pull                       update a system by attempting a git pull against each service');
+  console.log('fuge run <compose-file>         run a system');
+  console.log('fuge preview <compose-file>     preview a run command for a system');
+  console.log('fuge shell <compose-file>       start an interactive shell for a system');
+  console.log('fuge version                    version of fuge');
+  console.log('fuge help                       show this help');
 };
 
 
@@ -148,11 +147,7 @@ function start(argv) {
 }
 
 
-
 module.exports = start;
 if (require.main === module) {
   start(process.argv.slice(2));
 }
-
-
-

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "incite": "^2.0.0",
     "lodash": "^4.5.0",
     "minimist": "^1.2.0",
-    "ordinal": "^1.0.0",
+    "ordinal": "^0.0.4",
     "positive": "^1.0.9",
     "vorpal": "^1.10.8",
     "xenotype": "^0.4.0",

--- a/shell.js
+++ b/shell.js
@@ -346,8 +346,8 @@ module.exports = function() {
           var arr = [command];
             if (command === 'send'){
               if (opt !== undefined){
-                for (var i=0; i<opt.length; i++){
-                arr.push(opt[i]);
+                for (var i = 0; i < opt.length; i++) {
+                  arr.push(opt[i]);
                 }
               }
               action(arr, system, cb);

--- a/shell.js
+++ b/shell.js
@@ -390,15 +390,15 @@ module.exports = function() {
         inputStructure(com.command,'[process]',
           com.description, com.action, system);
       }
-      else if (com.command === 'debug') {
+      else if (com.command === 'debug'){
         inputStructure(com.command,'<process>',
           com.description, com.action, system);
       }
-      else if (com.command === 'profile') {
+      else if (com.command === 'profile'){
         inputStructure(com.command,'<process>',
           com.description, com.action, system);
       }
-      else if (com.command === 'send') {
+      else if (com.command === 'send'){
         inputStructure(com.command,'<process> <message>',
           com.description, com.action, system);
       }

--- a/shell.js
+++ b/shell.js
@@ -72,7 +72,7 @@ module.exports = function() {
             var proc = procs[procKey];
             table.push([container.name.green, 
                         container.type.green, 
-                        'running'.green, 
+                        container.profiling ? 'profiling'.green : 'running'.green, 
                         proc.monitor ? 'yes'.green : 'no'.red,
                         proc.tail ? 'yes'.green : 'no'.red,
                         counts[container.name] ? ('' + counts[container.name]).green : '0'.red]);
@@ -162,6 +162,35 @@ module.exports = function() {
     }
   };
 
+  var profileProcess = function(args, system, cb) {
+    if (!_runner.isProcessRunning(args.process)) {
+      _runner.profile(system, args, cb);
+    }
+    else {
+      console.log('process already running - terminate to profile');
+      cb();
+    }
+  };
+
+  var profileOptions = function(cmd) {
+    cmd
+      .option('--preview', 'Generates an SVG file, prerenders SVG inside HTML and outputs a PNG to the terminal (if possible) Depends on imagemagick (brew install imagemagick) If using iTerm 2.9+ image will be output to terminal Warning - depending on the amount of stacks this option can take tens of seconds')
+      .option('--delay, -d <delay>', 'Milliseconds. Delay before tracing begins (or before stacks are processed in the Linux case), allows us to ignore initialisation stacks (e.g. module loading).')
+      .option('--langs, -l', 'Color code the stacks by JS and C.')
+      .option('--tiers, -t', 'Overrides langs, Color code frames by type')
+      .option('--exclude, -x <list>', 'Exclude tiers or langs, comma seperated list',
+        ['v8', 'regexp', 'nativeC', 'nativeJS', 'core', 'deps', 'app', 'js', 'c'])
+      .option('--include <list>', 'Include tiers, Overwrites exclude. Really only useful for including the v8 tier (which is excluded by default).',
+        ['v8', 'regexp', 'nativeC', 'nativeJS', 'core', 'deps', 'app', 'js', 'c'])
+      .option('--theme <type>', 'Dark or Light theme, default: dark', ['dark', 'light'])
+      .option('--stacks-only', 'Don\'t generate the flamegraph, only create the stacks output. If assigned to '-' stacks output will come through stdout. Use this in combination with the -c gen argument to generate the flamegraph from raw stacks.',
+        ['false', 'true', '-'])
+      .option('--trace-info', 'Show output from dtrace or perf tools')
+      .option('--cmd, -c', 'Run a "0x command", possible commands are help and gen.', 
+        ['help', 'gen'])
+      .option('--timestamp-profiles', 'Adds the current timestamp to the Profile Folder\'s name minimizing collisions for in containerized environments');
+
+  };
 
 
   var watchProcess = function(args, system, cb) { 
@@ -264,6 +293,11 @@ module.exports = function() {
     description: 'start a process in debug mode'
   },
   {
+    command: 'profile',
+    action: profileProcess,
+    description: 'start a process with the profiler (0x)'
+  },
+  {
     command: 'watch',
     action: watchProcess,
     description: 'turn on watching for a process'
@@ -298,39 +332,47 @@ module.exports = function() {
 
   var inputStructure = function(command, type, description, action, system){
     // structures the commands and creates the vorpal instances
+    var cmd;
     if (type !== null){
-      vorpal
-      .command(command + type)
-      .autocomplete(procList)
-      .description(description)
-      .action(function (args, cb) {
-        var opt = args.process; // optional argument
-        var arr = [command];
-          if (command === 'send'){
-            if (opt !== undefined){
-              for (var i=0; i<opt.length; i++){
-              arr.push(opt[i]);
+      cmd = vorpal
+        .command(command + type)
+        .autocomplete(procList)
+        .description(description)
+        .action(function (args, cb) {
+          if (command === 'profile') {
+            return action(args, system, cb);
+          }
+          var opt = args.process; // optional argument
+          var arr = [command];
+            if (command === 'send'){
+              if (opt !== undefined){
+                for (var i=0; i<opt.length; i++){
+                arr.push(opt[i]);
+                }
               }
+              action(arr, system, cb);
+            }
+            else {
+              if (opt !== undefined){
+              arr.push(opt);
             }
             action(arr, system, cb);
-          }
-          else {
-            if (opt !== undefined){
-            arr.push(opt);
-          }
-          action(arr, system, cb);
-          }
-        });
+            }
+          });
+
+      if (command === 'profile') {
+        profileOptions(cmd);
       }
+    }
       // if no additional arguments are available
     else {
-      vorpal
-      .command(command)
-      .description(description)
-      .action(function (args, cb) {
-        var arr = [command];
-        action(arr, system, cb);
-      });
+      cmd = vorpal
+        .command(command)
+        .description(description)
+        .action(function (args, cb) {
+          var arr = [command];
+          action(arr, system, cb);
+        });
     }
   };
 
@@ -349,6 +391,10 @@ module.exports = function() {
           com.description, com.action, system);
       }
       else if (com.command === 'debug') {
+        inputStructure(com.command,'<process>',
+          com.description, com.action, system);
+      }
+      else if (com.command === 'profile') {
         inputStructure(com.command,'<process>',
           com.description, com.action, system);
       }


### PR DESCRIPTION
uses [0x](http://npm.im/0x) to profile a process, generating a flamegraph when the process has stopped

usage:
```
fuge> profile service1
(hit service with some work)
fuge> stop service
stopping: service1
sending SIGINT to  child process: 50984
sending SIGINT to  child process: 50985
sending SIGINT to  child process: 50986
sending SIGINT to  parent process: 50981
[service1 - 50981]: file:///Users/davidclements/z/nearForm/fuge/tst/service1/profile-50984/flamegraph.html
```

ps output of a profiled process:

```
name                           type            status          watch           tail            count
frontend                       process         stopped         yes             yes             0
service1                       process         profiling       no              yes             1
service2                       process         stopped         yes             yes             0
```

watching is always turned off for profiled processes (they create an isolate-v8 log that causes an infinite watch-reload loop, also changing files and reloading defeats the purpose of a profiling period)



the bulk of the implementation is in the counterpart PR at apparatus/fuge-runner#6

@pelger @AdrianRossouw @geek