### PR TITLE
fix typos, ignore node_modules when linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Fuge will ask you for some simple questions and then generate a system for you. 
 
 The structure has the following key files:
 
-* fuge - This directory contains two files
+* fuge - contains configuration files
   * compose-dev.yml - a docker-compose yaml file that serves as the main configuration reference for the system
   * docker-compose.yml - a docker-compose yaml file that has a pre-configured fuge environment
   * fuge-config.json - contains fuge specific settings and overrides not supported by docker-compose
@@ -71,7 +71,7 @@ The structure has the following key files:
 * api - contains a hapi or express REST api (based on your selection during initalization)
 * static - contains a static file server for your front-end code. maps the api service to /api.
 
-To start the generated system execute:
+To start the generated system, execute:
 
 ```
 fuge run ./fuge/compose-dev.yml

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "fuge": "./fuge.js"
   },
   "scripts": {
-    "lint": "jshint *.js && jshint **/*.js",
-    "test": "jshint *.js && jshint **/*.js && node test",
+    "lint": "jshint --exclude ./node_modules .",
+    "test": "npm run lint && node test",
     "coverage": "istanbul cover test/*Test.js && open ./coverage/lcov-report/index.html",
     "coverage-check": "istanbul cover test/*Test.js && istanbul check-coverage",
     "commit-check": "npm run lint"


### PR DESCRIPTION
I'm not exactly sure why jshint was being called twice but I removed it and excluded the node_modules dir. I wasn't able to commit (pre-hook) without excluding