### PR TITLE
Custom name for system folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "commist": "^1.0.0",
     "death": "^1.0.0",
     "fastseries": "^1.7.0",
+    "fs-extra": "^0.30.0",
     "fuge-proxy": "^0.4.0",
     "fuge-runner": "^0.7.4",
     "generator-fuge": "^0.5.3",


### PR DESCRIPTION
Fixes issue #21 

**cc:** @AdrianRossouw 

This introduces the possibility of specifying when calling the `fuge generate system` and extra argument which specifies the system name.
Invoking `fuge generate system foo` creates a folder foo from the current working directory in which the fuge topology is going to be created. 
In case the specified folder already exists, the wizard is going to prompt if the user either wants to override it or provide a new name for it.