### PR TITLE
Improve onExit command handler when exit command run

### DIFF
--- a/shell.js
+++ b/shell.js
@@ -33,14 +33,31 @@ module.exports = function (hardExit) {
   var commands
 
 
+  function shellOnExitCommand (command, system, cb) {
+    cb = cb || function () {}
+    return cmds.shell(command, system, cb)
+  }
+
   function stopSystem (args, system, cb) {
+    var onExitCommand = system.global.onExit || false
     runner.stopAll(system, function () {
       if (dns) { dns.stop() }
       if (morp) { morp.stop() }
       if (hardExit) {
-        process.exit(0)
+        if (onExitCommand) {
+          return shellOnExitCommand(onExitCommand, system, function () {
+            process.exit(0)
+          })
+        }
+        return process.exit(0)
       } else {
-        cb && cb()
+        if (onExitCommand && cb) {
+          return shellOnExitCommand(onExitCommand, system, cb)
+        } else if (onExitCommand && !cb) {
+          return shellOnExitCommand(onExitCommand, system)
+        } else if (cb) {
+          cb()
+        }
       }
     })
   }


### PR DESCRIPTION
onExit key on global schema is a shell script to execute like handler on exit command like docker-compose stop or anything you want to.

Pull request on fuge-config:
https://github.com/apparatus/fuge-config/pull/11

`
fuge_global:
  tail: false
  monitor: false
  monitor_excludes:
    - '**/node_modules/**'
    - '**/.git/**'
    - '**/*.log'
  onExit:
    docker-compose -f docker-compose.yml stop;
`